### PR TITLE
[実装例]トラップハンドラの実装

### DIFF
--- a/os/kernel.c
+++ b/os/kernel.c
@@ -8,11 +8,14 @@ extern char __bss[], __bss_end[];
 extern char __free_ram[], __free_ram_end[];
 extern char _binary_shell_bin_start[], _binary_shell_bin_size[];
 
+void kernel_entry(void);
+void handle_trap(void);
+
 void kernel_main(void) {
   memset(__bss, 0, (size_t)__bss_end - (size_t)__bss);
 
-  PANIC("booted!");
-  printf("unreachable here!\n");
+  WRITE_CSR(stvec, (uint32_t)kernel_entry);
+  __asm__ __volatile__("unimp");
 }
 
 __attribute__((section(".text.boot"))) __attribute__((naked)) void boot(void) {
@@ -44,4 +47,88 @@ struct sbiret sbi_call(long arg0, long arg1, long arg2, long arg3, long arg4,
 
 void putchar(char ch) {
   sbi_call(ch, 0, 0, 0, 0, 0, 0, 1 /* Console Putchar */);
+}
+
+__attribute__((aligned(4))) __attribute__((naked)) void kernel_entry(void) {
+  __asm__ __volatile__(
+      "csrw sscratch, sp\n"
+      "addi sp, sp, -4 * 31\n"
+
+      "sw ra, 4 * 0(sp)\n"
+      "sw gp, 4 * 1(sp)\n"
+      "sw tp, 4 * 2(sp)\n"
+      "sw t0, 4 * 3(sp)\n"
+      "sw t1, 4 * 4(sp)\n"
+      "sw t2, 4 * 5(sp)\n"
+      "sw t3, 4 * 6(sp)\n"
+      "sw t4, 4 * 7(sp)\n"
+      "sw t5, 4 * 8(sp)\n"
+      "sw t6, 4 * 9(sp)\n"
+      "sw a0, 4 * 10(sp)\n"
+      "sw a1, 4 * 11(sp)\n"
+      "sw a2, 4 * 12(sp)\n"
+      "sw a3, 4 * 13(sp)\n"
+      "sw a4, 4 * 14(sp)\n"
+      "sw a5, 4 * 15(sp)\n"
+      "sw a6, 4 * 16(sp)\n"
+      "sw a7, 4 * 17(sp)\n"
+      "sw s0, 4 * 18(sp)\n"
+      "sw s1, 4 * 19(sp)\n"
+      "sw s2, 4 * 20(sp)\n"
+      "sw s3, 4 * 21(sp)\n"
+      "sw s4, 4 * 22(sp)\n"
+      "sw s5, 4 * 23(sp)\n"
+      "sw s6, 4 * 24(sp)\n"
+      "sw s7, 4 * 25(sp)\n"
+      "sw s8, 4 * 26(sp)\n"
+      "sw s9, 4 * 27(sp)\n"
+      "sw s10, 4 * 28(sp)\n"
+      "sw s11, 4 * 29(sp)\n"
+
+      "csrr a0, sscratch\n"
+      "sw a0, 4 * 30(sp)\n"
+
+      "call handle_trap\n"
+
+      "lw ra, 4 * 0(sp)\n"
+      "lw gp, 4 * 1(sp)\n"
+      "lw tp, 4 * 2(sp)\n"
+      "lw t0, 4 * 3(sp)\n"
+      "lw t1, 4 * 4(sp)\n"
+      "lw t2, 4 * 5(sp)\n"
+      "lw t3, 4 * 6(sp)\n"
+      "lw t4, 4 * 7(sp)\n"
+      "lw t5, 4 * 8(sp)\n"
+      "lw t6, 4 * 9(sp)\n"
+      "lw a0, 4 * 10(sp)\n"
+      "lw a1, 4 * 11(sp)\n"
+      "lw a2, 4 * 12(sp)\n"
+      "lw a3, 4 * 13(sp)\n"
+      "lw a4, 4 * 14(sp)\n"
+      "lw a5, 4 * 15(sp)\n"
+      "lw a6, 4 * 16(sp)\n"
+      "lw a7, 4 * 17(sp)\n"
+      "lw s0, 4 * 18(sp)\n"
+      "lw s1, 4 * 19(sp)\n"
+      "lw s2, 4 * 20(sp)\n"
+      "lw s3, 4 * 21(sp)\n"
+      "lw s4, 4 * 22(sp)\n"
+      "lw s5, 4 * 23(sp)\n"
+      "lw s6, 4 * 24(sp)\n"
+      "lw s7, 4 * 25(sp)\n"
+      "lw s8, 4 * 26(sp)\n"
+      "lw s9, 4 * 27(sp)\n"
+      "lw s10, 4 * 28(sp)\n"
+      "lw s11, 4 * 29(sp)\n"
+      "lw sp, 4 * 30(sp)\n"
+
+      "sret\n");
+}
+
+void handle_trap(void) {
+  uint32_t scause = READ_CSR(scause);
+  uint32_t stval = READ_CSR(stval);
+  uint32_t sepc = READ_CSR(sepc);
+  PANIC("unexpected trap ocurred; scause=%x, stval=%x, sepc=%x", scause, stval,
+        sepc);
 }


### PR DESCRIPTION
# 思考プロセス

トラップハンドラを一番最初に実装することで、以後の開発でエラーが起きた時にすぐにトラップとして検知することができるので便利。その際、デバッグをしやすくするためにも、トラップの原因や発生箇所も一緒にメッセージとして表示したい。

## kernel_main

- トラップが発生するとRISC-Vでは、`stvec`レジスタにセットされているアドレスに制御を移すことから、`stvec`レジスタにトラップハンドラのアドレスを格納する必要がある
- 格納したらその後にunimp命令を実行することでトラップを起こせばトラップハンドラに制御を移し、トラップの挙動を確かめることができる
- `stvec`レジスタにトラップハンドラのアドレスを格納するのはカーネルプログラムの最初に行いたい。そのためkernel_main関数に記述する。またunimp命令はその後に実行すれば良い
- `stvec`レジスタに書き込むのにWRITE_CSRを使うことができる

## kernel_entry

- トラップハンドラに制御が移ったら、汎用レジスタの値をスタック領域に保存し、次にトラップの処理を実行し、最後に保存した汎用レジスタの値を復元してから、トラップが発生した箇所に制御を戻せば良い
- sret命令を使ってトラップから復帰すればトラップが発生した箇所に制御を戻すことができる（トラップ発生時にsepcにPCの値が入り、その後sret命令はsepcに格納されているアドレスをPCにセットするため）
- スタックに汎用レジスタの値を保存するにはスタックを拡張する必要がある。つまりスタックポインタ（sp）の値をいじる必要がある。その場合トラップ発生時のスタックポインタの値を保存する前にいじるのは良くないので、sscratchレジスタに一時的にスタックポインタの値を保存し、その後にスタックを拡張すれば良い
- 上記はレジスタ操作を行うためアセンブリで書くのが良さそう。その場合、トラップの処理までアセンブリで書くのはめんどくさいので、トラップの処理を行う関数を別途用意し、汎用レジスタの値をスタック領域に保存したら、その関数を呼び出す形で実装するのが良さそう
- まだUモードは使用されていないが、将来的にはUモードでトラップが発生した際もこのトラップハンドラを使用する予定なので、カーネルへの入り口という意味でこの関数はkernel_entryという名前をつけるのが良さそう
- この関数のアドレスをstvecに格納するため、この関数のアドレスは4バイトアラインである必要がある。そのため`__attribute__((aligned(4)))`をつける。同時にこの関数はアセンブリとして実行したいため、`__attribute__((naked))`もつける

## handle_trap

- kernerl_entry関数から呼び出す、トラップの処理を行う関数はhandle_trap関数と名付ける
- トラップの処理として、トラップが発生したことを知らせるためのメッセージを出す。その際、原因や発生箇所も表示する
- PANICを使ってメッセージを表示すれば良さそう。またscause、stval、sepcの値も同時に表示する。このとき値を読み取るのにREAD_CSRを使うことができる

# テスト

```c
$ ./run.sh
PANIC: kernel.c:47: unexpected trap scause=00000002, stval=ffffff84, sepc=8020015e
```

仕様書によると、`scause`の値が2の場合は”Illegal instruction”、つまり無効な命令の実行を試みたことが分かる。まさしく、`unimp`命令の期待通りの動作である。

```c
$ llvm-addr2line -e kernel.elf 8020015e
/Users/seiya/os-from-scratch/kernel.c:129
```

また、`sepc`の値がどこを指しているかも確認する。`unimp`命令を呼び出している行であれば上手くいっている。