### PR TITLE
[実装例]動的メモリ割り当ての実装

### DIFF
--- a/os/kernel.c
+++ b/os/kernel.c
@@ -10,12 +10,18 @@ extern char _binary_shell_bin_start[], _binary_shell_bin_size[];
 
 void kernel_entry(void);
 void handle_trap(void);
+paddr_t alloc_pages(uint32_t);
 
 void kernel_main(void) {
   memset(__bss, 0, (size_t)__bss_end - (size_t)__bss);
 
   WRITE_CSR(stvec, (uint32_t)kernel_entry);
-  __asm__ __volatile__("unimp");
+  paddr_t paddr0 = alloc_pages(2);
+  paddr_t paddr1 = alloc_pages(1);
+  printf("alloc_pages test: paddr0=%x\n", paddr0);
+  printf("alloc_pages test: paddr1=%x\n", paddr1);
+
+  PANIC("Hello, World!");
 }
 
 __attribute__((section(".text.boot"))) __attribute__((naked)) void boot(void) {
@@ -131,4 +137,15 @@ void handle_trap(void) {
   uint32_t sepc = READ_CSR(sepc);
   PANIC("unexpected trap ocurred; scause=%x, stval=%x, sepc=%x", scause, stval,
         sepc);
+}
+
+paddr_t alloc_pages(uint32_t n) {
+  static paddr_t next_paddr = (paddr_t)__free_ram;
+  paddr_t paddr = next_paddr;
+  next_paddr += n * PAGE_SIZE;
+
+  if (next_paddr > (paddr_t)__free_ram_end) PANIC("out of memory");
+
+  memset((void *)paddr, 0, n * PAGE_SIZE);
+  return paddr;
 }


### PR DESCRIPTION
# 思考プロセス

## alloc_pages

- 使用していない物理ページを必要に応じて割り当てられるようにしたい
- ページ数を引数として受け取り、割り当て可能なメモリ領域の先頭アドレスを返すalloc_pages関数を作る。解放処理は行わないので考えなくて良い
- 動的に割り当て可能なのは`__free_ram`から`__free_ram_end`までの領域であるため、この間のメモリを割り当てれば良い
- 割り当てられていないメモリの先頭アドレスを保持し続ける必要がある。そのため静的変数（またはグローバル変数）として保持する
- もしも割り当て可能なメモリ領域を超えてしまうようならパニックを起こす
- ページを割り当てる際はセキュリティ上、ゼロクリアしたものを渡す

## kernel_main

- 実際にalloc_pages関数を使ってメモリを割り当ててみて、割り当てたメモリの先頭アドレスを確認することで正常に動作しているか確かめることができる。そのため、確かめられるようにkernel_main関数を変更する

# テスト

```c
void kernel_main(void) {
    memset(__bss, 0, (size_t) __bss_end - (size_t) __bss);
    
    WRITE_CSR(stvec, (uint32_t) kernel_entry);

    paddr_t paddr0 = alloc_pages(2);
    paddr_t paddr1 = alloc_pages(1);
    printf("alloc_pages test: paddr0=%x\n", paddr0);
    printf("alloc_pages test: paddr1=%x\n", paddr1);

    PANIC("booted!");
}
```

最初のアドレス (`paddr0`) が`__free_ram`のアドレスと一致し、次のアドレス (`paddr1`) が最初のアドレスから2 * 4KB分進んだアドレス (16進数で`0x2000`足した数) と一致することを確認する。

```c
$ ./run.sh
alloc_pages test: paddr0=80221000
alloc_pages test: paddr1=80223000
```

```c
$ llvm-nm kernel.elf | grep __free_ram
80221000 R __free_ram
84221000 R __free_ram_end
```