### PR TITLE
[実装例]コンテキストスイッチの実装

### DIFF
--- a/os/kernel.c
+++ b/os/kernel.c
@@ -8,21 +8,49 @@ extern char __bss[], __bss_end[];
 extern char __free_ram[], __free_ram_end[];
 extern char _binary_shell_bin_start[], _binary_shell_bin_size[];
 
+struct process procs[PROCS_MAX];
+
+void putchar(char);
 void kernel_entry(void);
 void handle_trap(void);
 paddr_t alloc_pages(uint32_t);
 void map_page(uint32_t *, uint32_t, paddr_t, uint32_t);
+struct process *create_process(uint32_t);
+void switch_context(uint32_t *, uint32_t *);
+
+struct process *proc_a;
+struct process *proc_b;
+
+void proc_a_entry(void) {
+  printf("starting process A\n");
+  while (1) {
+    putchar('A');
+    switch_context(&proc_a->sp, &proc_b->sp);
+
+    for (int i = 0; i < 30000000; i++) __asm__ __volatile__("nop");
+  }
+}
+
+void proc_b_entry(void) {
+  printf("starting process B\n");
+  while (1) {
+    putchar('B');
+    switch_context(&proc_b->sp, &proc_a->sp);
+
+    for (int i = 0; i < 30000000; i++) __asm__ __volatile__("nop");
+  }
+}
 
 void kernel_main(void) {
   memset(__bss, 0, (size_t)__bss_end - (size_t)__bss);
 
   WRITE_CSR(stvec, (uint32_t)kernel_entry);
-  paddr_t paddr0 = alloc_pages(2);
-  paddr_t paddr1 = alloc_pages(1);
-  printf("alloc_pages test: paddr0=%x\n", paddr0);
-  printf("alloc_pages test: paddr1=%x\n", paddr1);
 
-  PANIC("Hello, World!");
+  proc_a = create_process((uint32_t)proc_a_entry);
+  proc_b = create_process((uint32_t)proc_b_entry);
+  proc_a_entry();
+
+  PANIC("unreachable here!");
 }
 
 __attribute__((section(".text.boot"))) __attribute__((naked)) void boot(void) {
@@ -167,4 +195,84 @@ void map_page(uint32_t *table1, uint32_t vaddr, paddr_t paddr, uint32_t flags) {
   uint32_t vpn0 = (vaddr >> 12) & 0x3ff;
   uint32_t *table0 = (uint32_t *)((table1[vpn1] >> 10) * PAGE_SIZE);
   table0[vpn0] = ((paddr / PAGE_SIZE) << 10) | flags | PAGE_V;
+}
+
+struct process *create_process(uint32_t pc) {
+  // 空いているプロセス管理構造体を探す
+  struct process *proc = NULL;
+  int i;
+  for (i = 0; i < PROCS_MAX; i++) {
+    if (procs[i].state == PROC_UNUSED) {
+      proc = &procs[i];
+      break;
+    }
+  }
+
+  if (!proc) PANIC("no free process slots");
+
+  // switch_context() で復帰できるように、スタックに呼び出し先保存レジスタを積む
+  uint32_t *sp = (uint32_t *)&proc->stack[sizeof(proc->stack)];
+  *--sp = 0;             // s11
+  *--sp = 0;             // s10
+  *--sp = 0;             // s9
+  *--sp = 0;             // s8
+  *--sp = 0;             // s7
+  *--sp = 0;             // s6
+  *--sp = 0;             // s5
+  *--sp = 0;             // s4
+  *--sp = 0;             // s3
+  *--sp = 0;             // s2
+  *--sp = 0;             // s1
+  *--sp = 0;             // s0
+  *--sp = (uint32_t)pc;  // ra
+
+  uint32_t *page_table = (uint32_t *)alloc_pages(1);
+
+  // カーネルのページをマッピングする
+  for (paddr_t paddr = (paddr_t)__kernel_base; paddr < (paddr_t)__free_ram_end;
+       paddr += PAGE_SIZE)
+    map_page(page_table, paddr, paddr, PAGE_R | PAGE_W | PAGE_X);
+
+  // 各フィールドを初期化
+  proc->pid = i + 1;
+  proc->state = PROC_RUNNABLE;
+  proc->sp = (uint32_t)sp;
+  proc->page_table = page_table;
+  return proc;
+}
+
+__attribute__((naked)) void switch_context(uint32_t *prev_sp,
+                                           uint32_t *next_sp) {
+  __asm__ __volatile__(
+      "addi sp, sp, -13 * 4\n"
+      "sw ra,  0  * 4(sp)\n"
+      "sw s0,  1  * 4(sp)\n"
+      "sw s1,  2  * 4(sp)\n"
+      "sw s2,  3  * 4(sp)\n"
+      "sw s3,  4  * 4(sp)\n"
+      "sw s4,  5  * 4(sp)\n"
+      "sw s5,  6  * 4(sp)\n"
+      "sw s6,  7  * 4(sp)\n"
+      "sw s7,  8  * 4(sp)\n"
+      "sw s8,  9  * 4(sp)\n"
+      "sw s9,  10 * 4(sp)\n"
+      "sw s10, 11 * 4(sp)\n"
+      "sw s11, 12 * 4(sp)\n"
+      "sw sp, (a0)\n"
+      "lw sp, (a1)\n"
+      "lw ra,  0  * 4(sp)\n"
+      "lw s0,  1  * 4(sp)\n"
+      "lw s1,  2  * 4(sp)\n"
+      "lw s2,  3  * 4(sp)\n"
+      "lw s3,  4  * 4(sp)\n"
+      "lw s4,  5  * 4(sp)\n"
+      "lw s5,  6  * 4(sp)\n"
+      "lw s6,  7  * 4(sp)\n"
+      "lw s7,  8  * 4(sp)\n"
+      "lw s8,  9  * 4(sp)\n"
+      "lw s9,  10 * 4(sp)\n"
+      "lw s10, 11 * 4(sp)\n"
+      "lw s11, 12 * 4(sp)\n"
+      "addi sp, sp, 13 * 4\n"
+      "ret\n");
 }


### PR DESCRIPTION
# 思考プロセス

コンテキストスイッチを実装することで、複数のプロセスを交互に切り替えて実行していくことができるようになる。

## create_process

- まずプロセスを作るcreate_process関数を定義する必要がある
- プロセスは前回実装したPCB（process構造体）を使って表現できる
- 最大でPROCS_MAX個のプロセスしか作ることができないため、PROCS_MAX個のプロセスを要素として持つ配列procsを定義し、それを使ってプロセスを管理することにする。使用していないプロセスは状態をPROC_UNUSEDに設定しておき、作成済みのプロセスは状態をPROC_RUNNABLEに変更すれば良い
- プロセスを作成するには、配列procsを走査して、未使用のプロセスを探して、各フィールドを初期化した上で返せば良い。もしも未使用のプロセスがなければカーネルパニックを起こす
- プロセス（process構造体）は、PID、プロセスの状態、カーネルスタック、スタックポインタ、ページテーブルをフィールドとして持つのでこれらを１つずつ初期化していけば良い
- まずPIDは配列の先頭から単純に１〜PROCS_MAX+1と割り振っていけば良い
- プロセスの状態は前述したようにPROC_RUNNABLEに変更する
- カーネルスタックはコンテキストスイッチの際にそのプロセスのコンテキスト（汎用レジスタの値）を保持しておくためのスペースなので、作成するときには0で初期化しておけば良い。ただし、リターンアドレスにはそのプロセスが実行したい関数の先頭アドレスで保持しておく必要がある（コンテキストスイッチした際にどのプログラムを実行するのかを指定する必要がある）。そのため、create_process関数の引数として受け取り、そのアドレスを使ってリターンアドレスを初期化する
- スタックポインタはカーネルスタックに汎用レジスタの値を格納し終わった際のスタックトップの値で初期化すれば良い。コンテキストスイッチの際はこのスタックポインタの値を使って汎用レジスタの値を復元するためである
- ページテーブルは、あらかじめカーネルのページをマッピングしたもので初期化する必要がある。そうしないとそのプロセスは仮想アドレスを使って物理アドレスにアクセスできなくなってしまう。map_page関数を使ってマップする。カーネルページは仮想アドレスと物理アドレスを同一のものとして扱いたいため、仮想ページと同じ物理ページをマップする。その際、フラグにはPAGE_R、PAGE_W、PAGE_Xを有効化したものを引数として渡す。カーネルページなのでUモードでアクセスできてしまうとセキュリティ上ダメなので、PAGE_Uは有効にしない
- 上記のように初期化したプロセス（process構造体）を返す

## switch_context

- プロセスを作れるようにしたら、次はプロセス間でコンテキストスイッチできるようにする必要がある
- コンテキストスイッチをするには、現在実行中のプロセスのコンテキスト（汎用レジスタの値）をカーネルスタックに保存し、切り替えたいプロセスのコンテキストを復元すれば良い
- 現在実行中のプロセスのコンテキストをカーネルスタックに保存したらその際のスタックポインタの値を現在実行中のプロセスのspフィールドに保存する必要がある。また切り替えたいプロセスのコンテキストを復元するために、コンテキストが格納されているカーネルスタックのスタックポインタの値を知る必要がある。そのため、両方のスタックポインタのポインタを引数としてとるswitch_context関数を作り、`switch_context(&proc_prev->sp, &proc_next->sp);`と呼び出せるようにしたい
- 切り替えたいプロセスのコンテキストを復元したら最後にret命令を実行することで、切り替えたいプロセスのリターンアドレスに制御を移すことができる

# テスト

```c
struct process *proc_a;
struct process *proc_b;

void proc_a_entry(void) {
    printf("starting process A\n");
    while (1) {
        putchar('A');
        switch_context(&proc_a->sp, &proc_b->sp);

        for (int i = 0; i < 30000000; i++)
            __asm__ __volatile__("nop");
    }
}

void proc_b_entry(void) {
    printf("starting process B\n");
    while (1) {
        putchar('B');
        switch_context(&proc_b->sp, &proc_a->sp);

        for (int i = 0; i < 30000000; i++)
            __asm__ __volatile__("nop");
    }
}

void kernel_main(void) {
    memset(__bss, 0, (size_t) __bss_end - (size_t) __bss);

    WRITE_CSR(stvec, (uint32_t) kernel_entry);

    proc_a = create_process((uint32_t) proc_a_entry);
    proc_b = create_process((uint32_t) proc_b_entry);
    proc_a_entry();

    PANIC("unreachable here!");
}
```

## switch_context(&proc_a->sp, &proc_b->sp);

proc_a_entry関数が実行されると、switch_context関数によってプロセスAの現在の状態が保存され、そのスタックトップがproc_a->spに格納され、proc_b->spに格納されているspからプロセスBの状態が復元される。これによってプロセスBを作るときに、スタックを初期化した際にraにセットしたproc_b_entry関数の先頭アドレスがraレジスタにセットされるため、proc_b_entry関数に制御が移る。

## __asm__ __volatile__("nop");

nop命令は「何もしない」命令で、これをしばらく繰り返すループを入れることで、文字での出力が速すぎてターミナルを操作できなくなるのを防いでいる。

```c
$ ./run.sh

starting process A
Astarting process B
BABABABABABABABABABABABABABABABABABABABABABABABABABA
```

起動時のメッセージが1回ずつ表示され、その後は「ABABAB...」と交互に表示される。