### PR TITLE
[実装例]システムコールの実装

### DIFF
--- a/os/shell.c
+++ b/os/shell.c
@@ -1,3 +1,3 @@
 #include "user.h"
 
-void main(void) { printf("Hello World from shell!\n"); }
+void main(void) { printf("shell > "); }

--- a/os/shell.c
+++ b/os/shell.c
@@ -1,6 +1,3 @@
 #include "user.h"
 
-void main(void) {
-  *((volatile int *)0x80200000) = 0x1234;
-  for (;;);
-}
+void main(void) { printf("Hello World from shell!\n"); }

--- a/os/user.c
+++ b/os/user.c
@@ -4,7 +4,21 @@ extern char __stack_top[];
 
 __attribute__((noreturn)) void exit(void) { for (;;); }
 
-void putchar(char c) { /* 後で実装する */ }
+int syscall(int sysno, int arg0, int arg1, int arg2) {
+  register int a0 __asm__("a0") = arg0;
+  register int a1 __asm__("a1") = arg1;
+  register int a2 __asm__("a2") = arg2;
+  register int a3 __asm__("a3") = sysno;
+
+  __asm__ __volatile__("ecall"
+                       : "=r"(a0)
+                       : "r"(a0), "r"(a1), "r"(a2), "r"(a3)
+                       : "memory");
+
+  return a0;
+}
+
+void putchar(char ch) { syscall(SYS_PUTCHAR, ch, 0, 0); }
 
 __attribute__((section(".text.start"))) __attribute__((naked)) void start(
     void) {


### PR DESCRIPTION
# 思考プロセス

システムコールを実装したい。

## トラップハンドラ

- システムコールを実現するにはUモードの際にトラップを起こし、Sモードに移行した際にシステムコールの処理を実行すれば良い。トラップを起こすにはecall命令を実行する
- トラップハンドラでは、通常のトラップなのか、システムコールなのかを見分ける必要がある。そのためにはecall命令が呼ばれたことによってトラップが発生したかどうかをscauseの値を確認することで判別できる
- またシステムコールの場合はトラップハンドラはシステムコールハンドラに制御を渡す

## システムコールハンドラ

- 通常、システムコールは複数存在するので、どのシステムコールが呼ばれたのかをシステムコール番号を確認して判別する必要がある。システムコール番号はecall命令に引数として渡されている。そのほかにも処理に必要な引数が渡される
- そのため、ecall命令からの引数をシステムコールハンドラに届けるために、トラップハンドラでは汎用レジスタの値が保存されているカーネルスタックのスタックポインタの値をシステムコールハンドラに渡す必要がある

## システムコール呼び出し

- ユーザー空間側ではecall命令に引数を渡して実行し、結果の値を受け取る必要がある

# テスト

```c
void main(void) {
    printf("Hello World from shell!\n");
}
```

`common.c`にある`printf`関数は`putchar`関数を使用しているが、ユーザーランド上のライブラリで`putchar`を実装したのでそのまま使うことができる。次のようにメッセージが表示されれば成功である。

```c
$ ./run.sh
Hello World from shell!
```